### PR TITLE
Fix combining files with identical names residing in different directories

### DIFF
--- a/lib/utils/combo.js
+++ b/lib/utils/combo.js
@@ -45,7 +45,8 @@ Combo.compile = function(inputFile, outputFile, config) {
   fsExt.mkdirS(tmpdir);
 
   var compressedFiles = files.map(function(file) {
-    var compressFile = path.join(tmpdir, path.basename(file));
+    var compressFile = path.join(tmpdir, path.relative(process.cwd(), file));
+    fsExt.mkdirS(path.dirname(compressFile));
     Compressor.compress(
         file,
         compressFile,


### PR DESCRIPTION
This fixes major bug which prevents having modules with same name in different directories.
