### PR TITLE
Update lib/actions/server.js

### DIFF
--- a/lib/actions/server.js
+++ b/lib/actions/server.js
@@ -240,8 +240,8 @@ var verReg = /\.\d+(-dev)?/;
 
 // 获取请求数据类型.
 Type.getReqType = function(queryPath) {
-  var ext = path.extname(queryPath);
-  if (!ext || verReg.test(ext)) {
+  var filePath = path.join(fileDir, queryPath);
+  if (fsExt.existsSync(filePath) && fs.statSync(filePath).isDirectory()) {
     return new DirType(queryPath);
   }
   return new FileType(queryPath);


### PR DESCRIPTION
使用 `stats.isDirectory()`  对象检查目录路径，解决目录名中存在 `.` 字符时判断错误的问题。
