### PR TITLE
Update lib/plugins/depCheck.js

### DIFF
--- a/lib/plugins/depCheck.js
+++ b/lib/plugins/depCheck.js
@@ -37,11 +37,10 @@ plugin.run = function(project, callback) {
       version = path.basename(dep);
       context = path.dirname(dep);
       deps.forEach(function(d) {
-        if (d.indexOf(context) > -1) {
-          var newVersion = path.basename(d);
-          if (newVersion != version) {
+        var newContext = path.dirname(d);
+        var newVersion = path.basename(d);
+        if (newContext == context && newVersion != version) {
             conflictMod.push(dep + ',' + d);
-          }
         }
       });
     }


### PR DESCRIPTION
如jquery和jquery.jscrollpane比对时，也会被认为是版本冲突
