### PR TITLE
修改 isVarModule 的规则

### DIFF
--- a/lib/utils/module_help.js
+++ b/lib/utils/module_help.js
@@ -46,7 +46,7 @@ exports.isUrl = function(filepath) {
 };
 
 // 检查模块是否是变量模板
-var VARS_RE = /\{\{([^{}]+)\}\}/;
+var VARS_RE = /\{([^{}]+)\}/;
 exports.isVarsModule = function(modName) {
   return VARS_RE.test(modName);
 };


### PR DESCRIPTION
根据 SeaJS 2.0 ，vars 配置对应的规则是 {} 而不是 {{}}
