### PR TITLE
升级 exeq 的版本，简化调用方式

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -52,7 +52,7 @@ module.exports = function(config) {
           'http://127.0.0.1:' + port + '/tests/runner.html?cov -S -R lcov'
         ]).on('done', function() {
           process.exit(0);
-        }).run();
+        });
       }
 
       exeq([
@@ -82,7 +82,7 @@ module.exports = function(config) {
             console.log(('   Fail to output ' + outputJSON).to.red.color);
           }
           process.exit(0);
-      }).run();
+      });
     });
   });
 };

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "async": "~0.2.9",
     "colorful": "~2.1.0",
     "commander": "~1.3.2",
-    "exeq": "~0.6.0",
+    "exeq": "~1.0.0",
     "form-data": "~0.1.2",
     "fstream": "~0.1.25",
     "fstream-ignore": "~0.0.7",


### PR DESCRIPTION
不再需要手动调用 `run()` 方法。
