### PR TITLE
ignore should not working in doc upload

### DIFF
--- a/lib/utils/tar.js
+++ b/lib/utils/tar.js
@@ -47,7 +47,7 @@ exports.create = function(source, target, callback, noIgnore) {
 
   if (noIgnore) {
     ignoreFiles = [];
-    ignoreArray = [];
+    ignoreArray = ['dist']; // always ignore dist when noIgnore
   }
 
   var istream = new Packer({


### PR DESCRIPTION
代码顺序问题导致 noIngore 为 true 时，package.json 里面的 spm.ignore 依然有效。
