### PR TITLE
fix doc publish 413 BUG

### DIFF
--- a/lib/doc.js
+++ b/lib/doc.js
@@ -173,6 +173,9 @@ function printResult(stats) {
 }
 
 function publish(argv, callback) {
+  // first clean doc directory
+  cleanDoc();
+  
   build(argv, function() {
     var pkg = readJSON('package.json');
     var registry;


### PR DESCRIPTION
执行spm doc publish之前需要先将_site目删除

原因是如果之前执行了spm doc，_site目录下会有额外的node_modules和spm_modules文件夹，执行upload的时候会导致文件流过长，上传失败。

![qq20151015-1 2x](https://cloud.githubusercontent.com/assets/1904938/10508157/d1ec8604-7357-11e5-8127-cd5297abbce4.png)
