### PR TITLE
改进在升级tnpm时spm doc命令失效问题

### DIFF
--- a/lib/doc.js
+++ b/lib/doc.js
@@ -258,6 +258,9 @@ function generateCode(cwd, pkg) {
   deps.forEach(function(dep) {
     if (dep === pkg.name) return;
     var rDep = dep;
+    if(~rDep.indexOf(pkg.name)){
+      rDep = './' + rDep.substr(pkg.name.length);
+    }
     if (isRelative(rDep)) {
       rDep = path.relative('./_site/', rDep);
       if (rDep.charAt(0) !== '.') {


### PR DESCRIPTION
修改tnpm的spm doc失效问题
spm doc不能正确解析原output中的内容，转换为绝对路径。
如果是同一个包，应该转换为相对路径